### PR TITLE
Improve travis and install Cassandra specific version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
 
 install:
   - pip install ansible
-  - ansible-galaxy install futurice.cassandra --roles-path=../ --ignore-errors
   - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
 
 script:

--- a/tasks/install_cassandra.yml
+++ b/tasks/install_cassandra.yml
@@ -11,10 +11,9 @@
 - action: apt update_cache=yes
   when: result_apt.changed
 
-- action: apt pkg="{{item}}" state=installed
+- action: apt pkg="{{item}}={{cassandra_version}}" state=installed
   with_items:
-    - dsc21
-    - cassandra-tools
+    - cassandra
 
 - service: name=cassandra state=started
   become: true

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,4 +6,4 @@
     user: root
     group: root
   roles:
-    - futurice.cassandra
+    - ansible-cassandra


### PR DESCRIPTION
Hi,

here's a PR to ensure that Cassandra is installed against config specific version and to run TravisCI with local changes, instead of what's pushed into Ansible Galaxy.
