### PR TITLE
Role idempotency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,8 @@ install:
 script:
   - "ansible-playbook -i tests/inventory tests/$SITE --syntax-check"
   - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo"
+  - >
+    ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
 
 install:
   - pip install ansible
-  - ansible-galaxy install futurice.cassandra --roles-path=../ --ignore-errors
   - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
 
 script:

--- a/tasks/install_cassandra.yml
+++ b/tasks/install_cassandra.yml
@@ -11,10 +11,9 @@
 - action: apt update_cache=yes
   when: result_apt.changed
 
-- action: apt pkg="{{item}}" state=installed
+- action: apt pkg="{{item}}={{cassandra_version}}" state=installed
   with_items:
-    - dsc21
-    - cassandra-tools
+    - cassandra
 
 - service: name=cassandra state=started
   become: true

--- a/tasks/install_java.yml
+++ b/tasks/install_java.yml
@@ -1,7 +1,11 @@
 ---
-- shell: "wget --header 'Cookie: oraclelicense=accept-securebackup-cookie' {{jdk_url}} -O /tmp/java7.tar.gz"
+- name: Download JDK
+  changed_when: False
+  shell: "wget --header 'Cookie: oraclelicense=accept-securebackup-cookie' {{jdk_url}} -O /tmp/java.tar.gz"
 
-- shell: tar -zxf /tmp/java7.tar.gz -C "{{jdk_install_path}}"
+- name: Extract JDK
+  unarchive: src=/tmp/java.tar.gz dest="{{jdk_install_path}}" copy=no
 
-- shell: update-alternatives --install /usr/bin/java java "/opt/jdk/jdk{{jdk_version}}/bin/java" 100
+- name: Select correct Java version
+  alternatives: name=java path="/opt/jdk/jdk{{jdk_version}}/bin/java" link=/usr/bin/java
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 - file: path="{{jdk_install_path}}" state=directory
 
 - shell: java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}'
+  changed_when: False
   register: java_version_result
 
 - include: install_java.yml
@@ -14,12 +15,14 @@
   become_user: root
 
 - shell: "lsb_release -c|cut -f2"
+  changed_when: False
   register: debian_codename_result
 
 - apt_repository: repo="deb {{debian_mirror}} {{debian_codename_result.stdout}} main contrib non-free" state=present
   when: (ansible_distribution == 'Debian')
 
 - shell: "dpkg -s cassandra|grep Version|cut -d' ' -f2"
+  changed_when: False
   register: cassandra_version_result
 
 - debug: msg="Cassandra {{cassandra_version_result.stdout}} JDK {{java_version_result.stdout}}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,4 +6,4 @@
     user: root
     group: root
   roles:
-    - futurice.cassandra
+    - ansible-cassandra


### PR DESCRIPTION
Makes this role idempotent (for single node installation) so any other 2–nd, ..., n–th run doesn't report any changes. Also depends on #1, and contains those commits, because that was the only way to ensure Travis passes.
